### PR TITLE
verify sshd config is good before restarting

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -48,7 +48,13 @@ template '/etc/ssh/sshd_config' do
   mode node['openssh']['config_mode']
   owner 'root'
   group node['openssh']['rootgroup']
+  notifies :run, 'execute[sshd-config-check]', :immediately
   notifies :restart, 'service[ssh]'
+end
+
+execute 'sshd-config-check' do
+  command 'sshd -t'
+  action :nothing
 end
 
 service_provider = Chef::Provider::Service::Upstart if 'ubuntu' == node['platform'] &&


### PR DESCRIPTION
If the sshd config is valid fail the chef run *before* restart sshd.
This allows the problem to be detected and fixed, which may be
difficult without ssh connectivity.

Man page quote for the extent of the validation:
  -t Test mode.  Only check the validity of the configuration file and
   sanity of the keys.  This is useful for updating sshd reliably as
   configuration options may change.