### PR TITLE
Handle SystemD on ubuntu 15.04+

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -57,8 +57,15 @@ execute 'sshd-config-check' do
   action :nothing
 end
 
-service_provider = Chef::Provider::Service::Upstart if 'ubuntu' == node['platform'] &&
-                                                       Chef::VersionConstraint.new('>= 12.04').include?(node['platform_version'])
+service_provider = nil
+
+if  'ubuntu' == node['platform']
+  if Chef::VersionConstraint.new('>= 15.04').include?(node['platform_version'])
+    service_provider = Chef::Provider::Service::Systemd
+  elsif Chef::VersionConstraint.new('>= 12.04').include?(node['platform_version'])
+    service_provider = Chef::Provider::Service::Upstart
+  end
+end
 
 service 'ssh' do
   provider service_provider


### PR DESCRIPTION
Systemd is the default in Ubuntu 15.04+ now.

Should resolve issue:
https://github.com/opscode-cookbooks/openssh/issues/60
