### PR TITLE
SSH reexec requires full path

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -53,7 +53,7 @@ template '/etc/ssh/sshd_config' do
 end
 
 execute 'sshd-config-check' do
-  command 'sshd -t'
+  command '/usr/sbin/sshd -t'
   action :nothing
 end
 


### PR DESCRIPTION
Hi, this pull request is to fix an issue where sshd refuses to run the config test unless called with the full path. Since you are always installing sshd from a package, it seems fairly safe to assume that it will live under /usr/sbin/sshd (assuming an Unix platform).

The Chef error output for the issue is copied below:

  * execute[sshd-config-check] action run
    
    ================================================================================
    Error executing action `run` on resource 'execute[sshd-config-check]'
    ================================================================================
    
    Mixlib::ShellOut::ShellCommandFailed
    ------------------------------------
    Expected process to exit with [0], but received '255'
    ---- Begin output of sshd -t ----
    STDOUT: 
    STDERR: sshd re-exec requires execution with an absolute path
    ---- End output of sshd -t ----
    Ran sshd -t returned 255
    
    Resource Declaration:
    ---------------------
    # In /var/chef/cache/cookbooks/openssh/recipes/default.rb
    
     55: execute 'sshd-config-check' do
     56:   command 'sshd -t'
     57:   action :nothing
     58: end
     59: 
    
    Compiled Resource:
    ------------------
    # Declared in /var/chef/cache/cookbooks/openssh/recipes/default.rb:55:in `from_file'
    
    execute("sshd-config-check") do
      action [:nothing]
      retries 0
      retry_delay 2
      default_guard_interpreter :execute
      command "sshd -t"
      backup 5
      returns 0
      declared_type :execute
      cookbook_name "openssh"
      recipe_name "default"
    end
